### PR TITLE
Mono Domain Set Config

### DIFF
--- a/clr_loader/__init__.py
+++ b/clr_loader/__init__.py
@@ -9,6 +9,7 @@ __all__ = ["get_mono", "get_netfx", "get_coreclr"]
 def get_mono(
     domain: Optional[str] = None,
     config_file: Optional[str] = None,
+    global_config_file: Optional[str] = None,
     libmono: Optional[str] = None,
     sgen: bool = True,
 ) -> Runtime:
@@ -17,7 +18,12 @@ def get_mono(
     if libmono is None:
         libmono = find_libmono(sgen)
 
-    impl = Mono(domain=domain, config_file=config_file, libmono=libmono)
+    impl = Mono(
+        domain=domain,
+        config_file=config_file,
+        global_config_file=global_config_file,
+        libmono=libmono,
+    )
     return Runtime(impl)
 
 

--- a/clr_loader/ffi/mono.py
+++ b/clr_loader/ffi/mono.py
@@ -16,6 +16,7 @@ void mono_jit_cleanup(MonoDomain *domain);
 MonoAssembly* mono_domain_assembly_open(MonoDomain *domain, const char *name);
 MonoImage* mono_assembly_get_image(MonoAssembly *assembly);
 
+void mono_domain_set_config(MonoDomain *domain, const char *base_dir, const char *config_file_name);
 void mono_config_parse(const char* path);
 
 MonoMethodDesc* mono_method_desc_new(const char* name, bool include_namespace);

--- a/clr_loader/mono.py
+++ b/clr_loader/mono.py
@@ -104,7 +104,7 @@ def initialize(
 
         # Load in global config (i.e /etc/mono/config)
         global_encoded = global_config_file or ffi.NULL
-        _MONO.mono_config_parse(global_config_file)
+        _MONO.mono_config_parse(global_encoded)
 
         # Even if we don't have a domain config file, we still need to set it
         # as something, see https://github.com/pythonnet/clr-loader/issues/8

--- a/clr_loader/mono.py
+++ b/clr_loader/mono.py
@@ -94,7 +94,7 @@ def initialize(config_file: str, libmono: str) -> None:
 
         _ROOT_DOMAIN = _MONO.mono_jit_init(b"clr_loader")
         _MONO.mono_config_parse(config_bytes)
-        _MONO.mono_domain_set_config(_ROOT_DOMAIN, ".", config_file.encode("utf8"))
+        _MONO.mono_domain_set_config(_ROOT_DOMAIN, b".", config_file.encode("utf8"))
         _check_result(_ROOT_DOMAIN, "Failed to initialize Mono")
         atexit.register(_release)
 

--- a/clr_loader/mono.py
+++ b/clr_loader/mono.py
@@ -1,4 +1,5 @@
 import atexit
+from typing import Optional
 
 from .ffi import load_mono, ffi
 
@@ -11,10 +12,21 @@ _ROOT_DOMAIN = None
 
 
 class Mono:
-    def __init__(self, libmono, domain=None, config_file=None):
+    def __init__(
+        self,
+        libmono,
+        *,
+        domain=None,
+        config_file: Optional[str] = None,
+        global_config_file: Optional[str] = None,
+    ):
         self._assemblies = {}
 
-        initialize(config_file=config_file, libmono=libmono)
+        initialize(
+            config_file=config_file,
+            global_config_file=global_config_file,
+            libmono=libmono,
+        )
 
         if domain is None:
             self._domain = _ROOT_DOMAIN
@@ -81,22 +93,28 @@ class MonoMethod:
         return unboxed[0]
 
 
-def initialize(config_file: str, libmono: str) -> None:
+def initialize(
+    libmono: str,
+    config_file: Optional[str] = None,
+    global_config_file: Optional[str] = None,
+) -> None:
     global _MONO, _ROOT_DOMAIN
     if _MONO is None:
         _MONO = load_mono(libmono)
 
         # Load in global config (i.e /etc/mono/config)
-        global_config_file = ffi.NULL
+        global_encoded = global_config_file or ffi.NULL
         _MONO.mono_config_parse(global_config_file)
 
-        # Even if we don't have a domain config file, we still need to set it as something
-        # https://github.com/pythonnet/clr-loader/issues/8
+        # Even if we don't have a domain config file, we still need to set it
+        # as something, see https://github.com/pythonnet/clr-loader/issues/8
         if config_file is None:
-            config_file = "substitute"
+            config_file = ""
+
+        config_encoded = config_file.encode("utf8")
 
         _ROOT_DOMAIN = _MONO.mono_jit_init(b"clr_loader")
-        _MONO.mono_domain_set_config(_ROOT_DOMAIN, b".", config_file.encode("utf8"))
+        _MONO.mono_domain_set_config(_ROOT_DOMAIN, b".", config_encoded)
         _check_result(_ROOT_DOMAIN, "Failed to initialize Mono")
         atexit.register(_release)
 

--- a/clr_loader/mono.py
+++ b/clr_loader/mono.py
@@ -94,7 +94,7 @@ def initialize(config_file: str, libmono: str) -> None:
 
         _ROOT_DOMAIN = _MONO.mono_jit_init(b"clr_loader")
         _MONO.mono_config_parse(config_bytes)
-        _MONO.mono_domain_set_config(_ROOT_DOMAIN, ".", config_file)
+        _MONO.mono_domain_set_config(_ROOT_DOMAIN, ".", config_file.encode("utf8"))
         _check_result(_ROOT_DOMAIN, "Failed to initialize Mono")
         atexit.register(_release)
 

--- a/clr_loader/mono.py
+++ b/clr_loader/mono.py
@@ -87,12 +87,14 @@ def initialize(config_file: str, libmono: str) -> None:
         _MONO = load_mono(libmono)
 
         if config_file is None:
+            config_file = "dummyConfig"
             config_bytes = ffi.NULL
         else:
             config_bytes = config_file.encode("utf8")
 
         _ROOT_DOMAIN = _MONO.mono_jit_init(b"clr_loader")
         _MONO.mono_config_parse(config_bytes)
+        _MONO.mono_domain_set_config(_ROOT_DOMAIN, ".", config_file)
         _check_result(_ROOT_DOMAIN, "Failed to initialize Mono")
         atexit.register(_release)
 


### PR DESCRIPTION
This PR addresses issue #8

In order for Mono to carry out some managed functions it needs to have a config set for the appdomain.
Here is the info from the docs.

```
Description

Used to set the system configuration for an appdomain

Without using this, embedded builds will get 'System.Configuration.ConfigurationErrorsException: Error Initializing the configuration system. ---> System.ArgumentException: The 'ExeConfigFilename' argument cannot be null.' for some managed calls.
```
Resource:
[Mono Docs](http://docs.go-mono.com/index.aspx?link=xhtml%3adeploy%2fmono-api-domains.html)



I added the definition for mono_domain_set_config,
and then during initialization I give it a "dummy" if config_file is none.

Nothing else changes and the error no longer reproduces.

