### PR TITLE
Bump to 0.1.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ with open("README.md", "r") as f:
 
 setup(
     name="clr_loader",
-    version="0.1.5",
+    version="0.1.6",
     description="Generic pure Python loader for .NET runtimes",
     author="Benedikt Reinartz",
     author_email="filmor@gmail.com",


### PR DESCRIPTION
Version bump after PR #9 so there can be a new version published.

Closes #8 

