### PR TITLE
Warn if Mono version is <= 6.12

### DIFF
--- a/clr_loader/ffi/mono.py
+++ b/clr_loader/ffi/mono.py
@@ -18,6 +18,8 @@ typedef enum {
 	MONO_DEBUG_FORMAT_DEBUGGER
 } MonoDebugFormat;
 
+char* mono_get_runtime_build_info (void);
+
 MonoDomain* mono_jit_init(const char *root_domain_name);
 void mono_jit_cleanup(MonoDomain *domain);
 void mono_jit_parse_options(int argc, char * argv[]);


### PR DESCRIPTION
Mono 6.8 (default on Ubuntu 20.04 LTS) tends to crash when clr-loader tries to find a .NET method. 6.12 works fine without code changes from our side. It is a good idea to warn users about potential issue and its resolution.