### PR TITLE
Fix issue 24: macOS: dotnet from fixed path when DOTNET_ROOT not set

### DIFF
--- a/clr_loader/util/find.py
+++ b/clr_loader/util/find.py
@@ -16,7 +16,7 @@ def find_dotnet_root() -> str:
     elif sys.platform == "darwin":
         dotnet_root = "/usr/local/share/dotnet"
 
-    if os.path.isdir(dotnet_root):
+    if dotnet_root is not None and os.path.isdir(dotnet_root):
         return dotnet_root
 
     # Try to discover dotnet from PATH otherwise

--- a/clr_loader/util/find.py
+++ b/clr_loader/util/find.py
@@ -13,8 +13,11 @@ def find_dotnet_root() -> str:
         # On Windows, the host library is stored separately from dotnet.exe for x86
         prog_files = os.environ.get("ProgramFiles")
         dotnet_root = os.path.join(prog_files, "dotnet")
-        if os.path.isdir(dotnet_root):
-            return dotnet_root
+    elif sys.platform == "darwin":
+        dotnet_root = "/usr/local/share/dotnet"
+
+    if os.path.isdir(dotnet_root):
+        return dotnet_root
 
     # Try to discover dotnet from PATH otherwise
     dotnet_path = shutil.which("dotnet")


### PR DESCRIPTION
On macOS, if DOTNET_ROOT is not set then look in fixed path `/usr/local/share/dotnet` for the dotnet executable. This fixes issue https://github.com/pythonnet/clr-loader/issues/24