### PR TITLE
Switch to Furo theme and use custom step

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,9 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: ammaraskar/sphinx-action@master
-      with:
-        docs-folder: doc/
+    - name: Build Sphinx documentation
+      run: |
+        pip install -r doc/requirements.txt
+        sphinx-build doc/ ./doc/_build/html/
+
     - name: Upload artifact
       # Automatically uploads an artifact from the './_site' directory by default
       uses: actions/upload-pages-artifact@v1

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -45,7 +45,7 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = "sphinx_rtd_theme"
+html_theme = "furo"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,1 +1,5 @@
-sphinx_rtd_theme
+sphinx
+
+# Theme, force pygments update
+furo>=2022.9.15
+pygments>=2.7


### PR DESCRIPTION
The "published" step uses an ages old version of Sphinx (2.2.4). This
should also fix issues with links to referenced functions.
