### PR TITLE
Fix to find dotnet root on 64-bits darwin system

### DIFF
--- a/clr_loader/util/find.py
+++ b/clr_loader/util/find.py
@@ -42,7 +42,10 @@ def find_dotnet_root() -> Path:
         prog_files = Path(prog_files)
         dotnet_root = prog_files / "dotnet"
     elif sys.platform == "darwin":
-        dotnet_root = Path("/usr/local/share/dotnet")
+        if sys.maxsize > 2**32: # is_64bits
+            dotnet_root = Path("/usr/local/share/dotnet/x64")
+        else:
+            dotnet_root = Path("/usr/local/share/dotnet")
 
     if dotnet_root is not None and dotnet_root.is_dir():
         return dotnet_root


### PR DESCRIPTION
 - Fix to find dotnet root on 64-bits darwin system
 - Ref: https://docs.python.org/3/library/platform.html#cross-platform
 - Fixes #36 