### PR TITLE
MAINT: add __version__ attribute

### DIFF
--- a/clr_loader/__init__.py
+++ b/clr_loader/__init__.py
@@ -20,6 +20,8 @@ __all__ = [
     "DotnetCoreRuntimeSpec",
 ]
 
+__version__ = "0.3.0.dev0"
+
 
 def get_mono(
     *,


### PR DESCRIPTION
Fixes #50. I see semantic versioning is used in this repository. Knowing that the latest stable release was `0.2.5`, I just increased the minor value to `0.3.0.dev0`.