### PR TITLE
Remove exception catching in MonoMethod Caller

### DIFF
--- a/clr_loader/mono.py
+++ b/clr_loader/mono.py
@@ -102,7 +102,6 @@ class MonoMethod:
         self._ptr = ptr
 
     def __call__(self, ptr, size):
-        exception = ffi.new("MonoObject**")
         params = ffi.new("void*[2]")
 
         # Keep these alive until the function is called by assigning them locally
@@ -112,7 +111,7 @@ class MonoMethod:
         params[0] = ptr_ptr
         params[1] = size_ptr
 
-        res = _MONO.mono_runtime_invoke(self._ptr, ffi.NULL, params, exception)
+        res = _MONO.mono_runtime_invoke(self._ptr, ffi.NULL, params, ffi.NULL)
         _check_result(res, "Failed to call method")
 
         unboxed = ffi.cast("int32_t*", _MONO.mono_object_unbox(res))


### PR DESCRIPTION
Removed a dummy exception that gets passed into the initializer.

This allows proper information to be printed when the function call fails.

Before:

```
Traceback (most recent call last):
  File "/Users/dante/Desktop/Repos/animo/AnimoTrainer/venv/bin/animo-learn", line 33, in <module>
    sys.exit(load_entry_point('animo-trainer', 'console_scripts', 'animo-learn')())
  File "/Users/dante/Desktop/Repos/animo/AnimoTrainer/animo_trainer/main.py", line 41, in main
    load(mono)
  File "/Users/dante/Desktop/Repos/animo/AnimoTrainer/venv/lib/python3.9/site-packages/pythonnet/__init__.py", line 143, in load
    if func(b"") != 0:
  File "/Users/dante/Desktop/Repos/animo/AnimoTrainer/venv/lib/python3.9/site-packages/clr_loader/types.py", line 64, in __call__
    return self._callable(ffi.cast("void*", buf_arr), len(buf_arr))
  File "/Users/dante/Desktop/Repos/animo/AnimoTrainer/venv/lib/python3.9/site-packages/clr_loader/mono.py", line 116, in __call__
    _check_result(res, "Failed to call method")
  File "/Users/dante/Desktop/Repos/animo/AnimoTrainer/venv/lib/python3.9/site-packages/clr_loader/mono.py", line 200, in _check_result
    raise RuntimeError(msg)
RuntimeError: Failed to call method

```


After

```

Unhandled Exception:
System.TypeInitializationException: The type initializer for 'System.Console' threw an exception. ---> System.TypeInitializationException: The type initializer for 'System.ConsoleDriver' threw an exception. ---> System.TypeInitializationException: The type initializer for 'Sys' threw an exception. ---> System.DllNotFoundException: /Users/dante/Desktop/Builds/LLM.app/Contents/Resources/Data/Managed/../lib/libmono-native.dylib assembly:<unknown assembly> type:<unknown type> member:(null)
  at (wrapper managed-to-native) Interop+Sys.LChflagsCanSetHiddenFlag()
  at Interop+Sys..cctor () [0x00000] in <5b93611b6ff043439d403fbb0837bc10>:0 
   --- End of inner exception stack trace ---
  at System.IO.FileSystem.FileExists (System.ReadOnlySpan`1[T] fullPath, System.Int32 fileType, Interop+ErrorInfo& errorInfo) [0x00007] in <5b93611b6ff043439d403fbb0837bc10>:0 
  at System.IO.FileSystem.DirectoryExists (System.ReadOnlySpan`1[T] fullPath, Interop+ErrorInfo& errorInfo) [0x00000] in <5b93611b6ff043439d403fbb0837bc10>:0 
  at System.IO.FileSystem.DirectoryExists (System.ReadOnlySpan`1[T] fullPath) [0x00000] in <5b93611b6ff043439d403fbb0837bc10>:0 
  at System.IO.Directory.Exists (System.String path) [0x0001e] in <5b93611b6ff043439d403fbb0837bc10>:0 
  at System.TermInfoDriver.SearchTerminfo (System.String term) [0x00044] in <5b93611b6ff043439d403fbb0837bc10>:0 
  at System.TermInfoDriver..ctor (System.String term) [0x0004b] in <5b93611b6ff043439d403fbb0837bc10>:0 
  at System.ConsoleDriver.CreateTermInfoDriver (System.String term) [0x00000] in <5b93611b6ff043439d403fbb0837bc10>:0 
  at System.ConsoleDriver..cctor () [0x0004d] in <5b93611b6ff043439d403fbb0837bc10>:0 
   --- End of inner exception stack trace ---
  at System.Console.SetupStreams (System.Text.Encoding inputEncoding, System.Text.Encoding outputEncoding) [0x00007] in <5b93611b6ff043439d403fbb0837bc10>:0 
  at System.Console..cctor () [0x0007d] in <5b93611b6ff043439d403fbb0837bc10>:0 
   --- End of inner exception stack trace ---
  at Python.Runtime.Loader.Initialize (System.IntPtr data, System.Int32 size) [0x00044] in /tmp/build-via-sdist-dq4gmg3h/pythonnet-3.0.1/src/runtime/Loader.cs:31 
[ERROR] FATAL UNHANDLED EXCEPTION: System.TypeInitializationException: The type initializer for 'System.Console' threw an exception. ---> System.TypeInitializationException: The type initializer for 'System.ConsoleDriver' threw an exception. ---> System.TypeInitializationException: The type initializer for 'Sys' threw an exception. ---> System.DllNotFoundException: /Users/dante/Desktop/Builds/LLM.app/Contents/Resources/Data/Managed/../lib/libmono-native.dylib assembly:<unknown assembly> type:<unknown type> member:(null)
  at (wrapper managed-to-native) Interop+Sys.LChflagsCanSetHiddenFlag()
  at Interop+Sys..cctor () [0x00000] in <5b93611b6ff043439d403fbb0837bc10>:0 
   --- End of inner exception stack trace ---
  at System.IO.FileSystem.FileExists (System.ReadOnlySpan`1[T] fullPath, System.Int32 fileType, Interop+ErrorInfo& errorInfo) [0x00007] in <5b93611b6ff043439d403fbb0837bc10>:0 
  at System.IO.FileSystem.DirectoryExists (System.ReadOnlySpan`1[T] fullPath, Interop+ErrorInfo& errorInfo) [0x00000] in <5b93611b6ff043439d403fbb0837bc10>:0 
  at System.IO.FileSystem.DirectoryExists (System.ReadOnlySpan`1[T] fullPath) [0x00000] in <5b93611b6ff043439d403fbb0837bc10>:0 
  at System.IO.Directory.Exists (System.String path) [0x0001e] in <5b93611b6ff043439d403fbb0837bc10>:0 
  at System.TermInfoDriver.SearchTerminfo (System.String term) [0x00044] in <5b93611b6ff043439d403fbb0837bc10>:0 
  at System.TermInfoDriver..ctor (System.String term) [0x0004b] in <5b93611b6ff043439d403fbb0837bc10>:0 
  at System.ConsoleDriver.CreateTermInfoDriver (System.String term) [0x00000] in <5b93611b6ff043439d403fbb0837bc10>:0 
  at System.ConsoleDriver..cctor () [0x0004d] in <5b93611b6ff043439d403fbb0837bc10>:0 
   --- End of inner exception stack trace ---
  at System.Console.SetupStreams (System.Text.Encoding inputEncoding, System.Text.Encoding outputEncoding) [0x00007] in <5b93611b6ff043439d403fbb0837bc10>:0 
  at System.Console..cctor () [0x0007d] in <5b93611b6ff043439d403fbb0837bc10>:0 
   --- End of inner exception stack trace ---
  at Python.Runtime.Loader.Initialize (System.IntPtr data, System.Int32 size) [0x00044] in /tmp/build-via-sdist-dq4gmg3h/pythonnet-3.0.1/src/runtime/Loader.cs:31 


```


Changing this allowed me to notice that my `libmono-native.dylib` file was misplaced.

It seems likely that being verbose in this scenario is preferable.