### PR TITLE
add trace options

### DIFF
--- a/clr_loader/__init__.py
+++ b/clr_loader/__init__.py
@@ -33,6 +33,8 @@ def get_mono(
     assembly_dir: Optional[str] = None,
     config_dir: Optional[str] = None,
     set_signal_chaining: bool = False,
+    trace_mask: Optional[str] = None,
+    trace_level: Optional[str] = None,
 ) -> Runtime:
     """Get a Mono runtime instance
 

--- a/clr_loader/ffi/mono.py
+++ b/clr_loader/ffi/mono.py
@@ -44,5 +44,8 @@ void mono_set_dirs(const char *assembly_dir, const char* config_dir);
 
 void mono_set_signal_chaining(bool chain_signals);
 
+void mono_trace_set_level_string(const char* value);
+void mono_trace_set_mask_string(const char* value);
+
 """
 )

--- a/clr_loader/mono.py
+++ b/clr_loader/mono.py
@@ -27,6 +27,8 @@ class Mono(Runtime):
         assembly_dir: Optional[str] = None,
         config_dir: Optional[str] = None,
         set_signal_chaining: bool = False,
+        trace_mask: Optional[str] = None,
+        trace_level: Optional[str] = None,
     ):
         self._assemblies: Dict[Path, Any] = {}
 
@@ -39,6 +41,8 @@ class Mono(Runtime):
             assembly_dir=assembly_dir,
             config_dir=config_dir,
             set_signal_chaining=set_signal_chaining,
+            trace_mask=trace_mask,
+            trace_level=trace_level,
         )
 
         if domain is None:
@@ -131,10 +135,18 @@ def initialize(
     assembly_dir: Optional[str] = None,
     config_dir: Optional[str] = None,
     set_signal_chaining: bool = False,
+    trace_mask: Optional[str] = None,
+    trace_level: Optional[str] = None,
 ) -> str:
     global _MONO, _ROOT_DOMAIN
     if _MONO is None:
         _MONO = load_mono(libmono)
+
+        if trace_mask is not None:
+            _MONO.mono_trace_set_mask_string(trace_mask.encode("utf8"))
+
+        if trace_level is not None:
+            _MONO.mono_trace_set_level_string(trace_level.encode("utf8"))
 
         if assembly_dir is not None and config_dir is not None:
             _MONO.mono_set_dirs(assembly_dir.encode("utf8"), config_dir.encode("utf8"))

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -56,6 +56,24 @@ def test_mono_signal_chaining(example_netstandard: Path):
     run_tests(asm)
 
 
+def test_mono_trace_mask(example_netstandard: Path):
+    from clr_loader import get_mono
+
+    mono = get_mono(trace_mask="all")
+    asm = mono.get_assembly(example_netstandard / "example.dll")
+
+    run_tests(asm)
+
+
+def test_mono_trace_level(example_netstandard: Path):
+    from clr_loader import get_mono
+
+    mono = get_mono(trace_level="message")
+    asm = mono.get_assembly(example_netstandard / "example.dll")
+
+    run_tests(asm)
+
+
 def test_mono_set_dir(example_netstandard: Path):
     from clr_loader import get_mono
 


### PR DESCRIPTION
See [Mono embedding guide](https://www.mono-project.com/docs/advanced/embedding/)

- The mono logger API now exposes only the ability to set the trace level and trace mask with the two functions:
`void mono_trace_set_mask_string (const char *value);`
`void mono_trace_set_level_string (const char *value);`

These are the [options](https://www.mono-project.com/docs/advanced/runtime/logging-runtime-events/#:~:text=Trace%20levels&text=The%20log%20level%20is%20set,%E2%80%9D%2C%20and%20%E2%80%9Cdebug%E2%80%9D.) that typically come via env vars: 