### PR TITLE
Support pythonnet for AppDomain

### DIFF
--- a/netfx_loader/ClrLoader.cs
+++ b/netfx_loader/ClrLoader.cs
@@ -26,6 +26,8 @@ namespace ClrLoader
         {
             get
             {
+                // This is needed in case the DLL was shadow-copied
+                // (Otherwise .Location would work)
                 string codeBase = Assembly.GetExecutingAssembly().CodeBase;
                 UriBuilder uri = new UriBuilder(codeBase);
                 string path = Uri.UnescapeDataString(uri.Path);

--- a/netfx_loader/DomainData.cs
+++ b/netfx_loader/DomainData.cs
@@ -10,24 +10,26 @@ namespace ClrLoader
     public static class DomainSetup
     {
         public delegate int EntryPoint(IntPtr buffer, int size);
+
         public static void StoreFunctorFromDomainData()
         {
             var domain = AppDomain.CurrentDomain;
             var assemblyPath = (string)domain.GetData("_assemblyPath");
             var typeName = (string)domain.GetData("_typeName");
             var function = (string)domain.GetData("_function");
-            var functor = GetFunctor(domain, assemblyPath, typeName, function);
+            var deleg = GetDelegate(domain, assemblyPath, typeName, function);
+            var functor = Marshal.GetFunctionPointerForDelegate(deleg);
+            domain.SetData("_thisDelegate", deleg);
             domain.SetData("_thisFunctor", functor);
         }
 
-        private static IntPtr GetFunctor(AppDomain domain, string assemblyPath, string typeName, string function)
+        private static Delegate GetDelegate(AppDomain domain, string assemblyPath, string typeName, string function)
         {
-            var assemblyName = AssemblyName.GetAssemblyName(assemblyPath).Name;
-            var assembly = domain.Load(AssemblyName.GetAssemblyName(assemblyPath));
+            var assemblyName = AssemblyName.GetAssemblyName(assemblyPath);
+            var assembly = domain.Load(assemblyName);
             var type = assembly.GetType(typeName, throwOnError: true);
             var deleg = Delegate.CreateDelegate(typeof(EntryPoint), type, function);
-            IntPtr result = Marshal.GetFunctionPointerForDelegate(deleg);
-            return result;
+            return deleg;
         }
     }
 
@@ -61,27 +63,46 @@ namespace ClrLoader
             };
         }
 
+        private static readonly object _lockObj = new object();
+
         public IntPtr GetFunctor(string assemblyPath, string typeName, string function)
         {
             if (_disposed)
                 throw new InvalidOperationException("Domain is already disposed");
 
-            installResolver(assemblyPath);
-
-            var key = (assemblyPath, typeName, function);
-
-            IntPtr result;
-            if (!_functors.TryGetValue(key, out result))
+            // neither the domain data nor the _functors dictionary is threadsafe
+            lock (_lockObj)
             {
-                Domain.SetData("_assemblyPath", assemblyPath);
-                Domain.SetData("_typeName", typeName);
-                Domain.SetData("_function", function);
+                installResolver(assemblyPath);
+                var assemblyName = AssemblyName.GetAssemblyName(assemblyPath).Name;
 
-                Domain.DoCallBack(new CrossAppDomainDelegate(DomainSetup.StoreFunctorFromDomainData));
-                result = (IntPtr)Domain.GetData("_thisFunctor");
-                _functors[key] = result;
+                var key = (assemblyName, typeName, function);
+
+                IntPtr result;
+                if (!_functors.TryGetValue(key, out result))
+                {
+                    Domain.SetData("_assemblyPath", assemblyPath);
+                    Domain.SetData("_typeName", typeName);
+                    Domain.SetData("_function", function);
+
+                    Domain.DoCallBack(new CrossAppDomainDelegate(DomainSetup.StoreFunctorFromDomainData));
+                    result = (IntPtr)Domain.GetData("_thisFunctor");
+                    if (result == IntPtr.Zero)
+                        throw new Exception($"Unable to get functor for {assemblyName}, {typeName}, {function}");
+
+                    // set inputs to StoreFunctorFromDomainData to null.
+                    // (There's no method to explicitly clear domain data)
+                    Domain.SetData("_assemblyPath", null);
+                    Domain.SetData("_typeName", null);
+                    Domain.SetData("_function", null);
+
+                    // the result has to remain in the domain data because we don't know when the
+                    // client of pyclr_get_function will actually invoke the functor, and if we
+                    // remove it from the domain data after returning it may get collected too early.
+                    _functors[key] = result;
+                }
+                return result;
             }
-            return result;
         }
 
         public void Dispose()

--- a/netfx_loader/DomainData.cs
+++ b/netfx_loader/DomainData.cs
@@ -1,46 +1,86 @@
 using System;
 using System.Collections.Generic;
 using System.Reflection;
+using System.Runtime.InteropServices;
 
 namespace ClrLoader
 {
     using static ClrLoader;
 
-    class DomainData : IDisposable
+    public static class DomainSetup
     {
         public delegate int EntryPoint(IntPtr buffer, int size);
+        public static void StoreFunctorFromDomainData()
+        {
+            var domain = AppDomain.CurrentDomain;
+            var assemblyPath = (string)domain.GetData("_assemblyPath");
+            var typeName = (string)domain.GetData("_typeName");
+            var function = (string)domain.GetData("_function");
+            var functor = GetFunctor(domain, assemblyPath, typeName, function);
+            domain.SetData("_thisFunctor", functor);
+        }
 
+        private static IntPtr GetFunctor(AppDomain domain, string assemblyPath, string typeName, string function)
+        {
+            var assemblyName = AssemblyName.GetAssemblyName(assemblyPath).Name;
+            var assembly = domain.Load(AssemblyName.GetAssemblyName(assemblyPath));
+            var type = assembly.GetType(typeName, throwOnError: true);
+            var deleg = Delegate.CreateDelegate(typeof(EntryPoint), type, function);
+            IntPtr result = Marshal.GetFunctionPointerForDelegate(deleg);
+            return result;
+        }
+    }
+
+    class DomainData : IDisposable
+    {
         bool _disposed = false;
 
         public AppDomain Domain { get; }
-        public Dictionary<(string, string, string), EntryPoint> _delegates;
+        public Dictionary<(string, string, string), IntPtr> _functors;
+        public HashSet<string> _resolvedAssemblies;
 
         public DomainData(AppDomain domain)
         {
             Domain = domain;
-            _delegates = new Dictionary<(string, string, string), EntryPoint>();
+            _functors = new Dictionary<(string, string, string), IntPtr>();
+            _resolvedAssemblies = new HashSet<string>();
         }
 
-        public EntryPoint GetEntryPoint(string assemblyPath, string typeName, string function)
+        private void installResolver(string assemblyPath)
+        {
+            var assemblyName = AssemblyName.GetAssemblyName(assemblyPath).Name;
+            if (_resolvedAssemblies.Contains(assemblyName))
+                return;
+            _resolvedAssemblies.Add(assemblyName);
+
+            AppDomain.CurrentDomain.AssemblyResolve += (sender, args) =>
+            {
+                if (args.Name.Contains(assemblyName))
+                    return Assembly.LoadFrom(assemblyPath);
+                return null;
+            };
+        }
+
+        public IntPtr GetFunctor(string assemblyPath, string typeName, string function)
         {
             if (_disposed)
                 throw new InvalidOperationException("Domain is already disposed");
 
+            installResolver(assemblyPath);
+
             var key = (assemblyPath, typeName, function);
 
-            EntryPoint result;
-
-            if (!_delegates.TryGetValue(key, out result))
+            IntPtr result;
+            if (!_functors.TryGetValue(key, out result))
             {
-                var assembly = Domain.Load(AssemblyName.GetAssemblyName(assemblyPath));
-                var type = assembly.GetType(typeName, throwOnError: true);
+                Domain.SetData("_assemblyPath", assemblyPath);
+                Domain.SetData("_typeName", typeName);
+                Domain.SetData("_function", function);
 
-                Print($"Loaded type {type}");
-                result = (EntryPoint)Delegate.CreateDelegate(typeof(EntryPoint), type, function);
-
-                _delegates[key] = result;
+                Domain.DoCallBack(new CrossAppDomainDelegate(DomainSetup.StoreFunctorFromDomainData));
+                result = (IntPtr)Domain.GetData("_thisFunctor");
+                _functors[key] = result;
             }
-
             return result;
         }
 
@@ -48,7 +88,7 @@ namespace ClrLoader
         {
             if (!_disposed)
             {
-                _delegates.Clear();
+                _functors.Clear();
 
                 if (Domain != AppDomain.CurrentDomain)
                     AppDomain.Unload(Domain);


### PR DESCRIPTION
Related to https://github.com/pythonnet/pythonnet/discussions/2053
Fixes #53

When using domain.Load for an assembly, the assembly resolution rules are awkward Even if the full path is given to the AssemblyName, when the domain tries to load the assembly, it does not use that context and tries to resolve the assembly using normal domain resolution rules, which would require an assembly resolver to be installed. However, the assembly resolver that is actually used at runtime is the one installed to the main appdomain.

This prevents a library like Python.Runtime.dll (used by pythonnet) which is not installed to the application base directory to be loaded by clr_loader.

It is possible for an assembly to run code in another appdomain (using DoCallBack), but only if that assembly is reachable from the BaseDirectory. ClrLoader was not reachable because the base directory was hardcoded to that which contained python.exe, and ClrLoader.dll is not found there. I fixed this by making the folder which contains ClrLoader.dll the BaseDirectory for app domains created by ClrLoader.

To fix this issue, the assembly resolver of the main appdomain is lazily extending to include paths needed for libraries passed into GetFunction, and GetFunction internally uses AppDomain.DoCallBack() to marshal the function pointer inside the target app domain, using global domain data to access the function pointer and return it to the user of clr_loader.



With these changes, the following block:

```
import clr_loader
netfx = clr_loader.get_netfx(domain="Python", config_file=config_file)
from pythonnet import load
load(netfx)
import System
print(System.AppDomain.CurrentDomain.FriendlyName)
```

will print "Python"


