### PR TITLE
hostfxr.py - Sanity check on shutdown that both _handle and _dll are present

### DIFF
--- a/clr_loader/hostfxr.py
+++ b/clr_loader/hostfxr.py
@@ -127,7 +127,7 @@ class DotnetCoreRuntime(Runtime):
         return ffi.cast("component_entry_point_fn", delegate_ptr[0])
 
     def shutdown(self) -> None:
-        if self._handle is not None:
+        if self._handle and self._dll:
             self._dll.hostfxr_close(self._handle)
             self._handle = None
 


### PR DESCRIPTION
During shutdown on alternative Python runtimes, either _handle or _dll may become None