### PR TITLE
Fix floor_version to use major and minor from version

### DIFF
--- a/clr_loader/util/runtime_spec.py
+++ b/clr_loader/util/runtime_spec.py
@@ -18,7 +18,8 @@ class DotnetCoreRuntimeSpec:
 
     @property
     def floor_version(self) -> str:
-        return f"{self.version[:3]}.0"
+        major, minor, _ = self.version.split(".")
+        return f"{major}.{minor}.0"
 
     @property
     def runtime_config(self) -> Dict[str, Any]:


### PR DESCRIPTION
it generate wrong config file when dotnet is above 9.
which will get 10..0. fixed it with more generic way.